### PR TITLE
Added templates for FOSS manifesto

### DIFF
--- a/HowTo.md
+++ b/HowTo.md
@@ -1,6 +1,6 @@
 # How to bring the FOSS Manifesto to your company
 
-If you want to implement a FOSS Manifesto in your company as well, please feel free to us this one right here! If you feel that you don't need to make any changes in terms of content and you fancy a cool design, we have something for you - a customizable pirate-style PDF!
+If you want to implement a FOSS Manifesto in your company as well, please feel free to us this one right here! If you feel that you don't need to make any changes in terms of content and you fancy a cool design, we have something for you - a customizable pirate-style PDF! For the unlikely event that you don't like the PDF, you might also take one of the templates in the `templates` folder and replace the placeholders `{company}` and `{the decision takers}`.
 
 There are two ways to create your own FOSS Manifesto: 
 
@@ -16,6 +16,6 @@ There are two ways to create your own FOSS Manifesto:
 
 **Number 2**
 
-Simply copy the Manifesto text from [here](https://github.com/mercedes-benz/mercedes-benz-foss-manifesto/blob/main/mercedes-benz-foss-manifesto.md) (there is a German version [here](https://github.com/mercedes-benz/mercedes-benz-foss-manifesto/blob/main/mercedes-benz-foss-manifesto_de.md)) and customize it as you please. 
+Simply copy the Manifesto text from [here](https://github.com/mercedes-benz/mercedes-benz-foss-manifesto/blob/main/mercedes-benz-foss-manifesto.md) (there is a German version [here](https://github.com/mercedes-benz/mercedes-benz-foss-manifesto/blob/main/mercedes-benz-foss-manifesto_de.md)) or from the `templates` folder, either the [english version](templates/template-foss-manifesto.md) or the [german version](templates/template-foss-manifesto_de.md) and customize it as you please. 
 
 You have any feedback? Please let us know!

--- a/templates/template-foss-manifesto.md
+++ b/templates/template-foss-manifesto.md
@@ -1,0 +1,33 @@
+# {company} FOSS Manifesto #
+
+## Preamble ##
+
+### {the decision takers}, ####
+
+- RESOLVED to incorporate Free and Open Source Software in our daily software development to improve the quality of our software as well as the speed of delivery,
+
+- DESIRING to be an active member in Open Source communities to benefit company, employee, and customer,
+
+- CONFIRMING the will to pave the road for their realization,
+
+- HAVE DECIDED to establish these FOSS guiding principles:
+
+## Company Principles ##
+
+C1. {company} shall support and encourage its employees to use, contribute to, and create FOSS projects both in Open and Inner Source endeavors. [Encourage FOSS]
+
+C2. {company} shall allow the appropriate time for its employees to participate in FOSS activities. [Facilitate FOSS Participation]
+
+C3. {company} shall encourage and facilitate learning and advancement of its employees through FOSS activities. [Advancement through FOSS]
+
+C4. {company} shall promote visibility in Open Source communities. [FOSS Visibility]
+
+## Employee Principles ##
+
+E1. An engineer shall look for Open and Inner Source alternatives before writing custom code or using proprietary alternatives. [Prefer FOSS]
+
+E2. An engineer shall strive to be active in the Inner Source communities. [Active FOSS Citizen]
+
+E3. An engineer shall contribute to Open Source projects within the scope of his or her day-to-day work. [Contribute FOSS]
+
+E4. Any employee shall always act responsibly in Open and Inner Source communities, with care and respect in both content and communication, in order to uphold a positive image for both himself / herself and the company. [Responsible FOSS Citizen]

--- a/templates/template-foss-manifesto_de.md
+++ b/templates/template-foss-manifesto_de.md
@@ -1,0 +1,33 @@
+# {company} FOSS Manifest #
+
+## Präambel ##
+
+### {the decision takers}, ###
+
+- ENTSCHLOSSEN, Free and Open Source Software in unsere tägliche Softwareentwicklung miteinzubeziehen, um die Qualität unserer Software und ihre Auslieferungsgeschwindigkeit zu erhöhen,
+
+- IM WUNSCH, ein aktives Mitglied in Open-Source-Communities zu sein zum Wohl von Unternehmen, Mitarbeiter und Kunde,
+
+- IN BESTÄTIGUNG des Willens, den Weg für ihre Umsetzung zu ebnen,
+
+HABEN ENTSCHIEDEN, diese FOSS-Leitprinzipien zu etablieren:
+
+## Unternehmensprinzipien ##
+
+C1. {company} unterstützt und ermutigt ihre Mitarbeiter/innen, FOSS-Projekte zu nutzen, dazu beizutragen und zu erstellen, sowohl in Open- als auch Inner-Source-Unterfangen. [Encourage FOSS]
+
+C2. {company} erlaubt ihren Mitarbeitern/innen, in einem angemessenen Zeitrahmen an FOSS-Aktivitäten teilzunehmen. [Facilitate FOSS Participation]
+
+C3. {company} ermutigt ihre Mitarbeiter/innen und ermöglicht es ihnen, mittels FOSS-Aktivitäten zu lernen und sich weiterzuentwickeln. [Advancement through FOSS]
+
+C4. {company} fördert die Sichtbarkeit in Open-Source-Communities. [FOSS Visibility]
+
+## Mitarbeiterprinzipien ## 
+
+E1. Vor der Erstellung von eigenem Code oder proprietären Alternativen sollen stets Open- und Inner-Source-Lösungen in Betracht gezogen werden. [Prefer FOSS]
+
+E2. Mitarbeiter/innen sollen danach streben, sich aktiv in Inner-Source-Communities einzubringen. [Active FOSS Citizen]
+
+E3. Ein/e Softwareentwickler/in möge im Rahmen seiner/ihrer täglichen Arbeit Beiträge zu Open-Source-Projekten leisten. [Contribute FOSS]
+
+E4. Jede/r Mitarbeiter/in soll sich stets verantwortungsvoll in Open- und Inner-Source-Communities verhalten, mit Sorgfalt und Respekt in Inhalt und Kommunikation, um ein positives Bild von sich und vom Unternehmen aufrechtzuerhalten. [Responsible FOSS Citizen]


### PR DESCRIPTION
Added english and german template for the FOSS manifesto that can be used by simply replacing the placeholders `{company}` and `{the decision takers}`.

This PR fixes #7.

Oliver Grueneberg <<oliver.grueneberg@mercedes-benz.com>>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)